### PR TITLE
Replace bignumber.js with big.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # smart-round
 
-![NPM Version](https://img.shields.io/npm/v/smart-round)
+![NPM Version](https://img.shields.io/npm/v/smart-round)![npm bundle size](https://img.shields.io/bundlephobia/minzip/smart-round)
 
 Round big numbers with arbitrary precision.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-round",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-round",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "big.js": "7.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "bignumber.js": "9.1.2"
+        "big.js": "7.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "19.7.1",
+        "@types/big.js": "6.2.2",
         "@vitest/coverage-v8": "3.0.6",
         "better-sort-package-json": "1.1.0",
         "commitlint-config-bloq": "1.1.0",
@@ -1421,6 +1422,13 @@
         "node": ">=8.10"
       }
     },
+    "node_modules/@types/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-e2cOW9YlVzFY2iScnGBBkplKsrn2CsObHQ2Hiw4V1sSyiGbgWL8IyqE3zFi1Pt5o1pdAtYkDAIsF3KKUPjdzaA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
@@ -2228,13 +2236,17 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+    "node_modules/big.js": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-7.0.1.tgz",
+      "integrity": "sha512-iFgV784tD8kq4ccF1xtNMZnXeZzVuXWWM+ERFzKQjv+A5G9HC8CY3DuV45vgzFFcW+u2tIvmF95+AzWgs6BjCg==",
       "license": "MIT",
       "engines": {
         "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -62,10 +62,6 @@
       "import": "./_esm/index.js",
       "require": "./_cjs/index.js",
       "types": "./_types/index.d.ts"
-    },
-    "./contracts": {
-      "import": "./_esm/contracts/index.js",
-      "types": "./_types/contracts/index.d.ts"
     }
   },
   "module": "./_esm/index.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Round big numbers with arbitrary precision",
   "keywords": [
-    "bignumber",
+    "big.js",
     "decimals",
     "precision",
     "round",
@@ -40,10 +40,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "bignumber.js": "9.1.2"
+    "big.js": "7.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "19.7.1",
+    "@types/big.js": "6.2.2",
     "@vitest/coverage-v8": "3.0.6",
     "better-sort-package-json": "1.1.0",
     "commitlint-config-bloq": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-round",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Round big numbers with arbitrary precision",
   "keywords": [
     "big.js",

--- a/src/roundingModes.ts
+++ b/src/roundingModes.ts
@@ -1,21 +1,16 @@
-import { BigNumber } from "bignumber.js";
+import { RoundingMode as BigJsRoundingMode } from "big.js";
 
 // Use this to allow easier configuration for consumers, without them needing
-// to import BigNumber
+// to import Big.js
 
 const roundingModes = [
-  "round-up",
   "round-down",
-  "round-ceil",
-  "round-floor",
   "round-half-up",
-  "round-half-down",
   "round-half-even",
-  "round-half-ceil",
-  "round-half-floor",
+  "round-up",
 ] as const;
 
 export type RoundingMode = (typeof roundingModes)[number];
 
-export const toBigNumberRoundingModes = (roundingMode: RoundingMode) =>
-  roundingModes.findIndex((r) => r === roundingMode)! as BigNumber.RoundingMode;
+export const toBigJsRoundingModes = (roundingMode: RoundingMode) =>
+  roundingModes.findIndex((r) => r === roundingMode)! as BigJsRoundingMode;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": false,
     "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
     "incremental": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
This PR replaces `bignumber.js` with `big.js`. The goal is to reduce the bundle size, as `big.js` is significantly smaller than `bignumber.js`

See the [bundle size for smart-round@2.0.0](https://bundlephobia.com/package/smart-round@2.0.0):


<img width="948" alt="image" src="https://github.com/user-attachments/assets/0f622c6e-8538-457d-a148-3a447ab8d00b" />

From the diagram, we can see that `bignumber.js` takes up  most of the bundle size

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/17f2ec90-365e-4be8-8106-50d774ed1f3d" />

If we compare [bignumber.js](https://bundlephobia.com/package/bignumber.js@9.3.0) with [big.js](https://bundlephobia.com/package/big.js@7.0.1), we see the latter is smaller, while having most of the same functionality (or we can get by with some calls to get the same functionality)


| BigNumber.js | Big.js |
| ------------- | ------------- |
| <img width="1095" alt="image" src="https://github.com/user-attachments/assets/004fb29d-df18-4d98-9f27-10e8b2c60336" /> | <img width="1127" alt="image" src="https://github.com/user-attachments/assets/f7107b7e-4505-46bc-9641-2322c4aee410" /> |


Tests pass so I expect it to have the same functionality.

Description commit by commit:

- df0c59b608c4961e6a495474bc7887bc4714b920 Removes an incorrect exports (There's no `contract` in this package ! It must have been a copy-paste error)
- b417f2bd8591dc4f225c9fe943263a3adeee3091 Replaces `bignumber.js` with `big.js`
- 115e3d81aaaa0342596e2d32ef12ad701dd560a3 Adds the bundle mingzipped size badge into the README
- ebea7b01a8833d910beb70218421d424f8a34b31 bumps the version.

Note I believe this should be  a breaking change because while the output should stay the same, the input used to accept a `BigNumber.js` instance, which is no longer accepted. We use `BigSource` now.